### PR TITLE
Connect front-end to sorted-by-provider and date index

### DIFF
--- a/src/app/Pages/Browser/AWS.tsx
+++ b/src/app/Pages/Browser/AWS.tsx
@@ -33,7 +33,7 @@ const AWS: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>AWS Image Browser</Title>
         </Bullseye>
       </PageSection>
-      <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-aws'}/>
+      <ImageDataTable tableColumns={columns} pathPrefix={'https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date-aws/1'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/AWS.tsx
+++ b/src/app/Pages/Browser/AWS.tsx
@@ -33,7 +33,7 @@ const AWS: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>AWS Image Browser</Title>
         </Bullseye>
       </PageSection>
-      <ImageDataTable tableColumns={columns} />
+      <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-aws'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/AWS.tsx
+++ b/src/app/Pages/Browser/AWS.tsx
@@ -33,7 +33,7 @@ const AWS: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>AWS Image Browser</Title>
         </Bullseye>
       </PageSection>
-      <ImageDataTable tableColumns={columns} pathPrefix={'https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date-aws/1'}/>
+      <ImageDataTable tableColumns={columns} pathPrefix={'https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date-aws'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/Azure.tsx
+++ b/src/app/Pages/Browser/Azure.tsx
@@ -34,7 +34,7 @@ const Azure: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>Azure Image Browser</Title>
         </Bullseye>
       </PageSection>
-        <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-azure'}/>
+        <ImageDataTable tableColumns={columns} pathPrefix={'https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date-azure'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/Azure.tsx
+++ b/src/app/Pages/Browser/Azure.tsx
@@ -34,7 +34,7 @@ const Azure: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>Azure Image Browser</Title>
         </Bullseye>
       </PageSection>
-        <ImageDataTable tableColumns={columns}/>
+        <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-azure'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/GCP.tsx
+++ b/src/app/Pages/Browser/GCP.tsx
@@ -34,7 +34,7 @@ const GCP: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>Google Cloud Image Browser</Title>
         </Bullseye>
       </PageSection>
-      <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-google'}/>
+      <ImageDataTable tableColumns={columns} pathPrefix={'https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date-google'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/Pages/Browser/GCP.tsx
+++ b/src/app/Pages/Browser/GCP.tsx
@@ -34,7 +34,7 @@ const GCP: React.FunctionComponent<{title: string}> = ({title}) => {
           <Title headingLevel="h1"  size={TitleSizes['4xl']}>Google Cloud Image Browser</Title>
         </Bullseye>
       </PageSection>
-      <ImageDataTable tableColumns={columns}/>
+      <ImageDataTable tableColumns={columns} pathPrefix={'https://cloudx-json-bucket.s3.amazonaws.com/images/v1/idx/list/sort-by-date-google'}/>
       <PageSection >
         <Bullseye>
           <Text component={TextVariants.small}>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>

--- a/src/app/components/DetailsView.tsx
+++ b/src/app/components/DetailsView.tsx
@@ -100,6 +100,8 @@ export default class DetailsView extends React.Component<IImageModalProps, IImag
       details
     } = this.props
 
+    console.log(details)
+
     let cliCommand
     let shellUrl
     let displayItems = [
@@ -167,7 +169,7 @@ export default class DetailsView extends React.Component<IImageModalProps, IImag
         break
 
       case 'google':
-        const image_path = details['url'].split('projects')[1]
+        const image_path = details['selflink'].split('projects')[1]
         cliCommand = `gcloud beta compute instances create ${machineName} \\
         --zone=${zoneName} \\
         --machine-type=${machineType} \\
@@ -207,7 +209,7 @@ export default class DetailsView extends React.Component<IImageModalProps, IImag
               })}
             </TextList>
             { details['provider'] != 'azure' &&
-              <Button component="a" href={details['url']} target="_blank" rel="noreferrer"  variant="danger">
+              <Button component="a" href={details['selflink']} target="_blank" rel="noreferrer"  variant="danger">
                 Launch now
               </Button>
             }

--- a/src/app/components/DetailsView.tsx
+++ b/src/app/components/DetailsView.tsx
@@ -100,8 +100,6 @@ export default class DetailsView extends React.Component<IImageModalProps, IImag
       details
     } = this.props
 
-    console.log(details)
-
     let cliCommand
     let shellUrl
     let displayItems = [
@@ -199,11 +197,11 @@ export default class DetailsView extends React.Component<IImageModalProps, IImag
           </TextContent>
           <TextContent id="test2" className="pf-u-py-xl">
             <TextList component="dl">
-              {displayItems.map((item, _index) => {
+              {displayItems.map((item, index) => {
                 return(
                   <div>
-                    <TextListItem component="dt">{item.Title}</TextListItem>
-                    <TextListItem component="dd">{item.Data}</TextListItem>
+                    <TextListItem key={`menu-title-${index}`} component="dt">{item.Title}</TextListItem>
+                    <TextListItem key={`menu-data-${index}`} component="dd">{item.Data}</TextListItem>
                   </div>
                 )
               })}

--- a/src/app/components/ImageDataTable.tsx
+++ b/src/app/components/ImageDataTable.tsx
@@ -130,22 +130,17 @@ const TableQuery = ({ tableData, tableColumns }) => {
   )
 }
 
-const ImageDataTable = ({tableColumns }) => {
+const ImageDataTable = ({tableColumns, pathPrefix}) => {
   const [page, setPage] = React.useState(1)
   const [tableData, setTableData] = useState(null)
 
   useEffect(() => {
-    fetch(`https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date/${page}`, {
-      method: 'get',
-    })
-    .then(res => res.json())
-    .then(data => {
-      setTableData(data)
-    })
+    loadData(page)
   }, [])
 
   const loadData = (newPage) => {
-    fetch(`https://poc.imagedirectory.cloud/images/v1/idx/list/sort-by-date/${newPage}`, {
+    // -1 is necessary as our index files start at 0 the react table at 1
+    fetch(`${pathPrefix}/${newPage-1}`, {
       method: 'get',
     })
     .then(res => res.json())

--- a/src/app/components/ImageDataTable.tsx
+++ b/src/app/components/ImageDataTable.tsx
@@ -27,7 +27,7 @@ const TableLayout = ({
       const reference = row.ref
       let fetchedDetails = {}
 
-      fetch(`https://cloudx-json-bucket.s3.amazonaws.com/images/v1/${reference}`, {
+      fetch(`https://poc.imagedirectory.cloud/images/v1/${reference}`, {
         method: 'get',
       })
       .then(res => res.json())


### PR DESCRIPTION
This PR enables the front-end to properly display the index files for sort-by-provider-and-date.