### PR TITLE
Fix grid breaking in Firefox on text components

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -15,39 +15,35 @@ const Footer = () => {
   return (
     <PageSection >
       <Bullseye>
-      <Grid component='span' hasGutter={true}>
-        <GridItem component='span'>
-          <Bullseye>
-            <TextContent>
-              <Text component='h5' className="pf-u-text-align-center">Can't find your favorite image <Emoji symbol="💔" />?</Text>
-            </TextContent>
-          </Bullseye>
-        </GridItem>
-        <GridItem>
-          <Bullseye>
-            <Button variant="danger">
-                <Link
-                  to='#'
-                  onClick={(e) => {
+        <Grid hasGutter={true} component='ul'>
+          <GridItem component='li'>
+              <TextContent>
+                Can't find your favorite image <Emoji symbol="💔" /> ?
+              </TextContent>
+          </GridItem>
+          <GridItem component='li'>
+            <Bullseye>
+              <Button variant="danger">
+                  <Link
+                    to='#'
+                    onClick={(e) => {
                       window.location.href = 'mailto:contact@imagedirectory.cloud'
                       e.preventDefault()
-                  }}
-              >
-                  <Emoji symbol="📨" /> {'Let us know!'}
-              </Link>
-            </Button>
-          </Bullseye>
-        </GridItem>
-        <GridItem>
-          <Bullseye>
-            <Text component='small'>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>
-          </Bullseye>
-        </GridItem>
-      </Grid>
-    </Bullseye>
-
-
-  </PageSection>
+                    }}
+                >
+                  <Emoji symbol="📨" /> Let us know!
+                </Link>
+              </Button>
+            </Bullseye>
+          </GridItem>
+          <GridItem component='li'>
+            <Bullseye>
+              <Text component='small'>{`Cloud Experience ${new Date().getFullYear()}.`}</Text>
+            </Bullseye>
+          </GridItem>
+        </Grid>
+      </Bullseye>
+    </PageSection>
   )
 }
 


### PR DESCRIPTION
Looking as it's supposed to (even with a slim button)