### PR TITLE
Remove patternfly defaults from static page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
 
   <meta charset="utf-8">
-  <title>Patternfly Seed</title>
+  <title>Cloud Image Directory</title>
   <meta id="appName" name="application-name" content="Patternfly Seed">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/images/favicon.png">
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <noscript>Enabling JavaScript is required to run this app.</noscript>
+  <noscript>Please enable Javascript in your browser to use the Cloud Image Directory.</noscript>
   <a class="github-fork-ribbon" href="https://github.com/redhatcloudx" data-ribbon="Fork us on GitHub" title="Fork me on GitHub">Fork us on GitHub</a>
   <div id="root"></div>
 </body>


### PR DESCRIPTION
This avoids showing "Patternfly Seed" in the browser tab until the page fully loads the Javascript needed for the application.