### PR TITLE
Make contact link more clear

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -17,20 +17,14 @@ const Footer = () => {
       <Bullseye>
         <Grid hasGutter={true} component='ul'>
           <GridItem component='li'>
-              <TextContent>
-                Can't find your favorite image <Emoji symbol="💔" /> ?
-              </TextContent>
+            <TextContent>
+              Can't find your favorite image <Emoji symbol="💔" /> ?
+            </TextContent>
           </GridItem>
           <GridItem component='li'>
             <Bullseye>
               <Button variant="danger">
-                  <Link
-                    to='#'
-                    onClick={(e) => {
-                      window.location.href = 'mailto:contact@imagedirectory.cloud'
-                      e.preventDefault()
-                    }}
-                >
+                <Link to='mailto:contact@imagedirectory.cloud'>
                   <Emoji symbol="📨" /> Let us know!
                 </Link>
               </Button>


### PR DESCRIPTION
Make it clear that the contact link is a `mailto:` link when you roll your mouse pointer over it.

Fixes #57