### PR TITLE
Fix: Webpack dev server cannot handle direct links to subdirectories

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common('development'), {
     port: PORT,
     compress: true,
     //inline: true,
-    historyApiFallback: true,
+    historyApiFallback: { index: "/", disableDotRule: true },
     //overlay: true,
     open: true,
     headers: {


### PR DESCRIPTION
What has changed?
 
- Add root API history fallback to enable one-page routing in local dev mode.