### PR TITLE
Remove v1 prefix from concatenated image data URL

### DIFF
--- a/src/app/components/ImageDataTable.tsx
+++ b/src/app/components/ImageDataTable.tsx
@@ -28,7 +28,7 @@ const TableLayout = ({
       const reference = row.ref
       let fetchedDetails = {}
 
-      fetch(`https://imagedirectory.cloud/images/v1/${reference}`, {
+      fetch(`https://imagedirectory.cloud/images/${reference}`, {
         method: 'get',
       })
         .then(res => res.json())
@@ -135,14 +135,14 @@ const ImageDataTable = ({ tableColumns, pathPrefix }) => {
           ...data,
           //+1 is necessary to calculate the total number of
           // entries as the first page is "0"
-          totalRows: (data['last']+1) * data['entries']
+          totalRows: (data['last'] + 1) * data['entries']
         })
       })
   }
 
   const loadData = (newPage) => {
     // -1 is necessary as our index files start at 0 the react table at 1
-    fetch(`${pathPrefix}/${newPage-1}`, {
+    fetch(`${pathPrefix}/${newPage - 1}`, {
       method: 'get',
     })
       .then(res => res.json())
@@ -166,8 +166,8 @@ const ImageDataTable = ({ tableColumns, pathPrefix }) => {
         variant={PaginationVariant.top}
         onSetPage={onSetPage}
         perPageOptions={[{
-          title:index['entries'],
-          value:index['entries']
+          title: index['entries'],
+          value: index['entries']
         }]}
         perPage={index['entries']}
       />


### PR DESCRIPTION
Maintenance fix to comply with changes in transformer image path construction. See redhatcloudx/transformer#585

This component won't be reused in v2 of the CID front-end.

Closes #101 