### PR TITLE
Enhance search and add filtering

### DIFF
--- a/src/app/components/ImageTable.tsx
+++ b/src/app/components/ImageTable.tsx
@@ -10,8 +10,13 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
-  Button
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateBody,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, ThProps, Tbody, Td } from '@patternfly/react-table';
 import { fetch } from 'cross-fetch'
 import { DetailsDrawer } from './DetailsDrawer';
@@ -38,7 +43,6 @@ export const ImageTable: React.FunctionComponent = () => {
   const [perPage, setPerPage] = React.useState(20);
   const [isDrawerExpanded, setIsExpanded] = React.useState(false);
   const [selectedImage, setSelectedImage] = React.useState({});
-
   const [providerSelections, setProviderSelections] = React.useState<string[]>([]);
   const [regionSelections, setRegionSelections] = React.useState<string[]>([]);
   const [architectureSelections, setArchitectureSelections] = React.useState<string[]>([]);
@@ -197,23 +201,23 @@ export const ImageTable: React.FunctionComponent = () => {
         setFilterConfig([
           {
             category: 'provider',
-            data: [...new Set(data.map(item => item['provider']))]
+            data: [...new Set(data.map((item: string) => item['provider']))]
           },
           {
             category: 'region',
-            data: [...new Set(data.map(item => item['region']))]
+            data: [...new Set(data.map((item: string) => item['region']))]
           },
           {
             category: 'architecture',
-            data: [...new Set(data.map(item => item['arch'].toLowerCase()))]
+            data: [...new Set(data.map((item: string) => item['arch'].toLowerCase()))]
           }
         ]);
       })
   };
 
-  const handleSearch = (event) => {
+  const handleSearch = (event: React.FormEvent<HTMLInputElement>) => {
     setIsExpanded(false);
-    setSearch(event.target.value);
+    setSearch(event.currentTarget.value);
     setPage(1);
   };
 
@@ -284,6 +288,30 @@ export const ImageTable: React.FunctionComponent = () => {
       details={selectedImage} />
   );
 
+  const emptyState = (
+    <EmptyState>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title size="lg" headingLevel="h4">
+        No results found
+      </Title>
+      <EmptyStateBody>No results match the filter criteria. Clear all filters and try again.</EmptyStateBody>
+      <EmptyStatePrimary>
+        <Button
+          variant="link"
+          onClick={() => {
+            setIsExpanded(false);
+            setSearch('');
+            setPage(1);
+            onFilterDelete('', '');
+          }}
+        >
+          Clear all filters
+        </Button>
+      </EmptyStatePrimary>
+    </EmptyState>
+  );
+  //add searchinput that clears once the setSearch is called
+
   return (
     <React.Fragment>
       <Title headingLevel='h1'>Browse Images</Title>
@@ -294,6 +322,7 @@ export const ImageTable: React.FunctionComponent = () => {
           <ToolbarItem variant="search-filter">
             <SearchInput
               onChange={handleSearch}
+              value={search}
               id='search'
               placeholder='Search by name'
             />
@@ -356,24 +385,32 @@ export const ImageTable: React.FunctionComponent = () => {
                 </Tr>
               </Thead>
               <Tbody>
-                {sortedImageData.map((image: ImageData) => (
-                  <Tr key={image.name}>
-                    <Td dataLabel={columnNames.name}>{image.name}</Td>
-                    <Td dataLabel={columnNames.provider}>{image.provider}</Td>
-                    <Td dataLabel={columnNames.region}>{image.region}</Td>
-                    <Td dataLabel={columnNames.arch}>{image.arch}</Td>
-                    <Td dataLabel={columnNames.date}><p>{new Date(image.date).toDateString()}</p></Td>
-                    <Td>
-                      <Button
-                        aria-expanded={isDrawerExpanded}
-                        onClick={e => onDrawerOpenClick(image)}
-                        variant='link'
-                        isInline>
-                        Launch now
-                      </Button>
+                {sortedImageData.length > 0 &&
+                  sortedImageData.map((image: ImageData) => (
+                    <Tr key={image.name}>
+                      <Td dataLabel={columnNames.name}>{image.name}</Td>
+                      <Td dataLabel={columnNames.provider}>{image.provider}</Td>
+                      <Td dataLabel={columnNames.region}>{image.region}</Td>
+                      <Td dataLabel={columnNames.arch}>{image.arch}</Td>
+                      <Td dataLabel={columnNames.date}><p>{new Date(image.date).toDateString()}</p></Td>
+                      <Td>
+                        <Button
+                          aria-expanded={isDrawerExpanded}
+                          onClick={e => onDrawerOpenClick(image)}
+                          variant='link'
+                          isInline>
+                          Launch now
+                        </Button>
+                      </Td>
+                    </Tr>
+                  ))}
+                {sortedImageData.length === 0 && (
+                  <Tr>
+                    <Td colSpan={8}>
+                      {emptyState}
                     </Td>
                   </Tr>
-                ))}
+                )}
               </Tbody>
             </Table>
           </DrawerContentBody>

--- a/src/app/components/ImageTableFilter.tsx
+++ b/src/app/components/ImageTableFilter.tsx
@@ -1,0 +1,120 @@
+import React, { ReactElement } from 'react';
+import { FilterIcon } from '@patternfly/react-icons';
+import {
+  Badge,
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Popper,
+  MenuGroup
+} from '@patternfly/react-core';
+
+export const ImageTableFilter: React.FunctionComponent<{
+  onFilterSelect: (
+    event: React.MouseEvent | undefined,
+    itemId: string | number | undefined) => void,
+  isFilterSelected: (
+    category: string,
+    itemId: string) => boolean,
+  category: string,
+  filters: string[],
+  totalFilterCount: number,
+}> = ({
+  onFilterSelect,
+  category,
+  filters,
+  isFilterSelected,
+  totalFilterCount
+}) => {
+    const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    const toggleRef = React.useRef<HTMLButtonElement>(null);
+    const menuRef = React.useRef<HTMLDivElement>(null);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+      const handleKeys = (event: KeyboardEvent) => {
+        if (isOpen && menuRef.current?.contains(event.target as Node)) {
+          if (event.key === 'Escape' || event.key === 'Tab') {
+            setIsOpen(!isOpen);
+            toggleRef.current?.focus();
+          }
+        }
+      };
+
+      const handleClickOutside = (event: MouseEvent) => {
+        if (isOpen && !menuRef.current?.contains(event.target as Node)) {
+          setIsOpen(false);
+        }
+      };
+      window.addEventListener('keydown', handleKeys);
+      window.addEventListener('click', handleClickOutside);
+      return () => {
+        window.removeEventListener('keydown', handleKeys);
+        window.removeEventListener('click', handleClickOutside);
+      };
+    }, [isOpen, menuRef]);
+
+    const onToggleClick = (ev: React.MouseEvent) => {
+      ev.stopPropagation();
+      setTimeout(() => {
+        if (menuRef.current) {
+          const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+          firstElement && (firstElement as HTMLElement).focus();
+        }
+      }, 0);
+      setIsOpen(!isOpen);
+    };
+
+    const createMenuGroup = (category: string, items: string[]): ReactElement => {
+      return (
+        <MenuGroup label={category}>
+          {
+            items.map((item, index) => {
+              return (
+                <MenuItem hasCheck key={`${category}-${index}`} isSelected={isFilterSelected(category, item)} itemId={`${category}/${item}`}>
+                  {item}
+                </MenuItem>
+              )
+            })
+          }
+        </MenuGroup>
+      )
+    }
+
+    const menuItemGroups = createMenuGroup(category, filters)
+
+    const menu = (
+      <Menu
+        isScrollable
+        ref={menuRef}
+        id="image-filter-menu"
+        onSelect={onFilterSelect}
+      >
+        <MenuContent maxMenuHeight="300px">
+          <MenuList>
+            {menuItemGroups}
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    );
+
+    const toggle = (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        icon={<FilterIcon />}
+      >
+        Filter {category}
+        {totalFilterCount > 0 && <Badge isRead>{totalFilterCount}</Badge>}
+      </MenuToggle>
+    )
+
+    return (
+      <div ref={containerRef}>
+        <Popper direction="down" trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />
+      </div>
+    );
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es6"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
**What has changed?**
- Added filters for provider, region and architecture.
- Increased tsconfig target from ES5 to ES6 (introduction of "Set")
[Screencast from 2023-08-02 10-48-22.webm](https://github.com/redhatcloudx/cloud-image-directory-frontend/assets/47077340/13356759-5dbe-4f24-8923-6f7232c3fc44)

**Open questions**
@KKoukiou  @lucasgarfield  I'm not a fan of the constant resizing that is happening once filters are selected.
Can we somehow add a default size to the table so we won't have this screen shake?
What can be improved in this implementation?

closes #119 #66 